### PR TITLE
Bugfixes

### DIFF
--- a/ZappMerchantLib/PBBAAppUtils.h
+++ b/ZappMerchantLib/PBBAAppUtils.h
@@ -29,7 +29,7 @@
 /**
  *  Check if at least one PBBA enabled CFI app is installed on the current device.
  *
- *  @discussion You must whitelist first the 'zapp' scheme in your Info.plist file under the LSApplicationQueriesSchemes key.
+ *  You must whitelist first the 'zapp' scheme in your Info.plist file under the LSApplicationQueriesSchemes key.
  *
  *  @return YES if CFI app is installed.
  */
@@ -46,6 +46,9 @@
 
 /**
  *  Show PBBA popup view controller.
+ *
+ *  It opens the CFI app automatically (without displaying the popup) if the device has CFI app installed and the user has tapped 'Open banking app' button.
+ *  Before opening the CFI app automatically it will also close any instance of error PBBAPopupViewController which is presented.
  *
  *  @param presenter   The presenter controller which will present the popup view controller.
  *  @param secureToken The human friendly transaction retrieval identifier issued by Zapp.

--- a/ZappMerchantLib/PBBAAppUtils.m
+++ b/ZappMerchantLib/PBBAAppUtils.m
@@ -46,9 +46,25 @@
     NSAssert(brn.length == 6, @"[PBBAAppUtils] 'brn' length must be 6 characters.");
     
     if ([PBBALibraryUtils shouldLaunchCFIApp]) {
+        
+        // Dismiss any instance of presented error popup before opening the CFI app
+        if ([presenter.presentedViewController isKindOfClass:[PBBAPopupViewController class]]) {
+            [presenter dismissViewControllerAnimated:NO completion:nil];
+        }
+        
         if ([self openBankingApp:secureToken]) {
             return nil;
         }
+    }
+    
+    if ([presenter.presentedViewController isKindOfClass:[PBBAPopupViewController class]]) {
+        PBBAPopupViewController *pbbaPopupVC = (PBBAPopupViewController *) presenter.presentedViewController;
+        [pbbaPopupVC updateWithSecureToken:secureToken
+                                       brn:brn];
+        
+        pbbaPopupVC.delegate = delegate;
+        
+        return pbbaPopupVC;
     }
     
     PBBAPopupViewController *pbbaPopupVC = [[PBBAPopupViewController alloc] initWithSecureToken:secureToken
@@ -65,6 +81,17 @@
 {
     NSAssert(presenter, @"[PBBAAppUtils] 'presenter' is a mandatory parameter.");
     NSAssert(errorMessage, @"[PBBAAppUtils] 'errorMessage' is a mandatory parameter.");
+    
+    if ([presenter.presentedViewController isKindOfClass:[PBBAPopupViewController class]]) {
+        PBBAPopupViewController *pbbaPopupVC = (PBBAPopupViewController *) presenter.presentedViewController;
+        [pbbaPopupVC updateWithErrorCode:errorCode
+                              errorTitle:errorTitle
+                            errorMessage:errorMessage];
+        
+        pbbaPopupVC.delegate = delegate;
+        
+        return pbbaPopupVC;
+    }
     
     PBBAPopupViewController *pbbaPopupVC = [[PBBAPopupViewController alloc] initWithErrorCode:errorCode
                                                                                    errorTitle:errorTitle

--- a/ZappMerchantLib/PBBAButton.m
+++ b/ZappMerchantLib/PBBAButton.m
@@ -295,6 +295,7 @@ currentPBBATitleView = _currentPBBATitleView;
 
     if (enabled) {
         [self stopAnimating];
+        [self.activityTimer invalidate];
         [UIView animateWithDuration:0.2 animations:^{
             self.backgroundColor = self.originalBackgroundColor;
         }];

--- a/ZappMerchantLib/PBBALibraryUtils.m
+++ b/ZappMerchantLib/PBBALibraryUtils.m
@@ -49,7 +49,13 @@ static NSDictionary *sPBBACustomConfig = nil;
 + (BOOL)isCFIAppAvailable
 {
     NSURL *urlToCheck = [NSURL URLWithString:kPBBACFIAppUrlScheme];
-    return [[UIApplication sharedApplication] canOpenURL:urlToCheck];
+    BOOL cfiAppAvailable = [[UIApplication sharedApplication] canOpenURL:urlToCheck];
+    
+    if (!cfiAppAvailable) {
+        [self saveFlagValue:NO forKey:kPBBARememberCFIAppLaunchKey];
+    }
+    
+    return cfiAppAvailable;
 }
 
 + (BOOL)openBankingApp:(NSString *)secureToken
@@ -64,7 +70,12 @@ static NSDictionary *sPBBACustomConfig = nil;
 
 + (void)registerCFIAppLaunch
 {
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kPBBARememberCFIAppLaunchKey];
+    [self saveFlagValue:YES forKey:kPBBARememberCFIAppLaunchKey];
+}
+
++ (void)saveFlagValue:(BOOL)value forKey:(NSString *)key
+{
+    [[NSUserDefaults standardUserDefaults] setBool:value forKey:key];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 

--- a/ZappMerchantLib/PBBAPopupCoordinator.h
+++ b/ZappMerchantLib/PBBAPopupCoordinator.h
@@ -177,7 +177,7 @@ typedef NS_ENUM(NSInteger, PBBAPopupEComLayoutType) {
 /**
  *  Force coordinator to automatically update the layout.
  *
- *  @discussion The coordinator will decide to which layout to switch according to the current state of transaction / payment request.
+ *  The coordinator will decide to which layout to switch according to the current state of transaction / payment request.
  */
 - (void)updateLayout;
 

--- a/ZappMerchantLib/PBBAPopupViewController.h
+++ b/ZappMerchantLib/PBBAPopupViewController.h
@@ -39,6 +39,13 @@
 @optional
 
 /**
+ *  Inform delegate that user has decided to close the popup by pressing the close button.
+ *
+ *  @param pbbaPopupViewController The instance of popup view controller.
+ */
+- (void)pbbaPopupViewControllerDidCloseByUser:(nonnull PBBAPopupViewController *)pbbaPopupViewController;
+
+/**
  *  Inform delegate that PBBAPopupViewController will appear on the screen.
  *
  *  @param pbbaPopupViewController The instance of popup view controller.

--- a/ZappMerchantLib/PBBAPopupViewController.m
+++ b/ZappMerchantLib/PBBAPopupViewController.m
@@ -317,6 +317,11 @@ static UIEdgeInsets const kScreenMargins = {0, 20, 0, 20};
                         completion:(dispatch_block_t)completion
 {
     [self dismissViewControllerAnimated:YES completion:^{
+        
+        if ([self.delegate respondsToSelector:@selector(pbbaPopupViewControllerDidCloseByUser:)]) {
+            [self.delegate pbbaPopupViewControllerDidCloseByUser:self];
+        }
+        
         if (completion) completion();
     }];
 }

--- a/ZappMerchantLibTests/PBBAAppUtilsTests.m
+++ b/ZappMerchantLibTests/PBBAAppUtilsTests.m
@@ -28,6 +28,7 @@ describe(@"For PBBAAppUtils class", ^{
     NSString *validBRN = @"ABCABC";
     NSString *validSecureToken = @"123456789";
     UIViewController *validPresenter = [UIViewController new];
+    PBBAPopupViewController *validPopupVC = [PBBAPopupViewController new];
     
     __block UIViewController *mockPresenter;
     __block PBBAPopupViewController *mockPBBAPopupViewController;
@@ -96,18 +97,26 @@ describe(@"For PBBAAppUtils class", ^{
     
     it(@"a call to showPBBAPopup:secureToken:brn:delegate: should succeed for valid parameters", ^{
         
+        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:nil withCount:2];
         [[mockPresenter should] receive:@selector(presentViewController:animated:completion:) withArguments:mockPBBAPopupViewController, any(), any()];
-        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:mockPBBAPopupViewController];
+        
+        [PBBAAppUtils showPBBAPopup:mockPresenter secureToken:validSecureToken brn:validBRN delegate:nil];
+    });
+    
+    it(@"a call to showPBBAPopup:secureToken:brn:delegate: should update the presented popup for valid parameters", ^{
+        
+        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:validPopupVC withCount:2];
+        [[mockPresenter shouldNot] receive:@selector(presentViewController:animated:completion:)];
         
         PBBAPopupViewController *presentedVC = [PBBAAppUtils showPBBAPopup:mockPresenter secureToken:validSecureToken brn:validBRN delegate:nil];
         
-        [[presentedVC should] equal:mockPBBAPopupViewController];
+        [[presentedVC should] equal:validPopupVC];
     });
     
     it(@"a call to showPBBAPopup:secureToken:brn:delegate: should not present PBBA popup if there is already presented something", ^{
         
         [[mockPresenter should] receive:@selector(presentViewController:animated:completion:) withArguments:mockPBBAPopupViewController, any(), any()];
-        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:validPresenter];
+        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:validPresenter withCount:2];
         
         PBBAPopupViewController *presentedVC = [PBBAAppUtils showPBBAPopup:mockPresenter secureToken:validSecureToken brn:validBRN delegate:nil];
         
@@ -119,6 +128,8 @@ describe(@"For PBBAAppUtils class", ^{
         [[PBBALibraryUtils should] receive:@selector(shouldLaunchCFIApp) andReturn:theValue(YES)];
         [[PBBALibraryUtils should] receive:@selector(openBankingApp:) andReturn:theValue(YES)];
         
+        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:mockPBBAPopupViewController];
+        [[mockPresenter should] receive:@selector(dismissViewControllerAnimated:completion:)];
         [[mockPresenter shouldNot] receive:@selector(presentViewController:animated:completion:) withArguments:mockPBBAPopupViewController, any(), any()];
         
         PBBAPopupViewController *presentedVC = [PBBAAppUtils showPBBAPopup:mockPresenter secureToken:validSecureToken brn:validBRN delegate:nil];
@@ -143,17 +154,29 @@ describe(@"For PBBAAppUtils class", ^{
     it(@"a call to showPBBAErrorPopup:errorCode:errorTitle:errorMessage:delegate: should succeed for valid parameters", ^{
         
         [[mockPresenter should] receive:@selector(presentViewController:animated:completion:) withArguments:mockPBBAPopupViewController, any(), any()];
-        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:mockPBBAPopupViewController];
+        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:nil withCount:2];
         
-        PBBAPopupViewController *presentedVC = [PBBAAppUtils showPBBAErrorPopup:mockPresenter errorCode:testString errorTitle:testString errorMessage:testString delegate:nil];
+        [PBBAAppUtils showPBBAErrorPopup:mockPresenter errorCode:testString errorTitle:testString errorMessage:testString delegate:nil];
+    });
+    
+    it(@"a call to showPBBAErrorPopup:errorCode:errorTitle:errorMessage:delegate: should update the presented popup for valid parameters", ^{
         
-        [[presentedVC should] equal:mockPBBAPopupViewController];
+        [[mockPresenter shouldNot] receive:@selector(presentViewController:animated:completion:)];
+        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:validPopupVC withCount:2];
+        
+        PBBAPopupViewController *presentedVC = [PBBAAppUtils showPBBAErrorPopup:mockPresenter
+                                                                      errorCode:testString
+                                                                     errorTitle:testString
+                                                                   errorMessage:testString
+                                                                       delegate:nil];
+        
+        [[presentedVC should] equal:validPopupVC];
     });
     
     it(@"a call to showPBBAErrorPopup:errorCode:errorTitle:errorMessage:delegate: should not present PBBA popup if there is already presented something", ^{
         
         [[mockPresenter should] receive:@selector(presentViewController:animated:completion:) withArguments:mockPBBAPopupViewController, any(), any()];
-        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:validPresenter];
+        [[mockPresenter should] receive:@selector(presentedViewController) andReturn:validPresenter withCount:2];
         
         PBBAPopupViewController *presentedVC = [PBBAAppUtils showPBBAErrorPopup:mockPresenter errorCode:testString errorTitle:testString errorMessage:testString delegate:nil];
         


### PR DESCRIPTION
Bugfixes:
- Update the presented instance of PBBA popup instead of ignoring it on "showPBBAPopup..." call.
- Dismiss any instance of PBBA popup before opening the bank app on "showPBBAPopup..." call.
- Reset the remembered CFI app launch flag in case if no bank app detected.

Improvements:
- Add a new method to PBBAPopupViewControllerDelegate which is called when popup is dismissed as results of the user action.